### PR TITLE
Add check for anti-detect browser tampering INTER-1902

### DIFF
--- a/src/app/web-scraping/api/flights/route.ts
+++ b/src/app/web-scraping/api/flights/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<FlightsRespon
   const event = fingerprintResult.data;
   const identification = event.identification;
   const bot = event.bot;
-  const antiDetectBroswer = event.tampering_details?.anti_detect_browser;
+  const antiDetectBrowser = event.tampering_details?.anti_detect_browser;
 
   // Backdoor for demo and testing purposes
   // If bot detection is disabled, just send the result
@@ -68,7 +68,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<FlightsRespon
 
   // Anti-detect browsers often overlap with bots
   // https://docs.fingerprint.com/docs/smart-signals-reference#anti_detect_browser
-  if (antiDetectBroswer) {
+  if (antiDetectBrowser) {
     return NextResponse.json(
       {
         severity: 'error',

--- a/src/app/web-scraping/api/flights/route.ts
+++ b/src/app/web-scraping/api/flights/route.ts
@@ -32,8 +32,10 @@ export async function POST(req: NextRequest): Promise<NextResponse<FlightsRespon
     return NextResponse.json({ severity: 'error', message: fingerprintResult.error }, { status: 403 });
   }
 
-  const identification = fingerprintResult.data.identification;
-  const bot = fingerprintResult.data.bot;
+  const event = fingerprintResult.data;
+  const identification = event.identification;
+  const bot = event.bot;
+  const antiDetectBroswer = event.tampering_details?.anti_detect_browser;
 
   // Backdoor for demo and testing purposes
   // If bot detection is disabled, just send the result
@@ -61,6 +63,18 @@ export async function POST(req: NextRequest): Promise<NextResponse<FlightsRespon
     return NextResponse.json(
       { severity: 'error', message: 'Server error, unexpected bot detection value.' },
       { status: 500 },
+    );
+  }
+
+  // Anti-detect browsers often overlap with bots
+  // https://docs.fingerprint.com/docs/smart-signals-reference#anti_detect_browser
+  if (antiDetectBroswer) {
+    return NextResponse.json(
+      {
+        severity: 'error',
+        message: 'Anti-detect browser tampering detected, potentially a bot, access denied.',
+      },
+      { status: 403 },
     );
   }
 


### PR DESCRIPTION
Introduces a check for `anti_detect_browser` in the web scraping demo. If detected, it returns a 403 Forbidden response, as this often indicates bot activity and can be used to circumvent bot detection.