### PR TITLE
Add iOS Simulator row in demo playground

### DIFF
--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -60,6 +60,7 @@ test.describe('Playground page', () => {
 
     await page.getByText('IP Blocklist', { exact: true }).waitFor();
     await page.getByText('Emulator', { exact: true }).waitFor();
+    await page.getByText('iOS Simulator', { exact: true }).waitFor();
     await page.getByText('Proximity Detection', { exact: true }).waitFor();
     await page.getByText('Tampered Request', { exact: true }).waitFor();
     await page.getByText('VPN (Mobile)', { exact: true }).waitFor();

--- a/src/app/playground/Playground.tsx
+++ b/src/app/playground/Playground.tsx
@@ -627,6 +627,19 @@ export function Playground() {
       },
       { content: PLAYGROUND_COPY.iosOnly, className: tableStyles.neutral },
     ],
+    [
+      {
+        content: [
+          <DocsLink
+            href='https://docs.fingerprint.com/docs/smart-signals-reference#ios-simulator-detection'
+            key='ios-simulator'
+          >
+            iOS Simulator
+          </DocsLink>,
+        ],
+      },
+      { content: PLAYGROUND_COPY.iosOnly, className: tableStyles.neutral },
+    ],
   ];
 
   return (


### PR DESCRIPTION
* Adds a new row in mobile signals list for iOS Simulator Detection
* Links to docs page and iOS SDK